### PR TITLE
[FEAT] B_USER_01 - 유저 entity 작성 및 회원가입 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,10 +24,18 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
+
+    //Hibernate Spatial
+    implementation 'org.hibernate:hibernate-spatial:6.5.2.Final'
+    implementation 'org.hibernate:hibernate-core:6.5.2.Final'
+
+    //MySQL
+    runtimeOnly 'com.mysql:mysql-connector-j'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,9 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/backend/yamukja/common/config/SecurityConfig.java
+++ b/src/main/java/backend/yamukja/common/config/SecurityConfig.java
@@ -1,0 +1,13 @@
+package backend.yamukja.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/backend/yamukja/common/config/SecurityConfig.java
+++ b/src/main/java/backend/yamukja/common/config/SecurityConfig.java
@@ -2,10 +2,23 @@ package backend.yamukja.common.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 public class SecurityConfig {
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests((requests) -> requests
+                        .requestMatchers("/api/user/join").permitAll()  // 회원가입 접근 허용
+                        .anyRequest().authenticated()  // 그 외 요청은 인증 필요
+                );
+
+        return http.build();
+    }
+
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();

--- a/src/main/java/backend/yamukja/common/dto/ErrorResponseDto.java
+++ b/src/main/java/backend/yamukja/common/dto/ErrorResponseDto.java
@@ -1,0 +1,12 @@
+package backend.yamukja.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+@Data
+@AllArgsConstructor
+public class ErrorResponseDto {
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/backend/yamukja/common/exception/GeneralException.java
+++ b/src/main/java/backend/yamukja/common/exception/GeneralException.java
@@ -1,0 +1,24 @@
+package backend.yamukja.common.exception;
+
+import backend.yamukja.common.dto.ErrorResponseDto;
+import lombok.Builder;
+import lombok.Data;
+import org.springframework.http.HttpStatus;
+
+@Data
+@Builder
+public class GeneralException extends RuntimeException {
+    private final String message;
+    private final HttpStatus status;
+
+    public GeneralException(String message, HttpStatus status) {
+        super(message);
+        this.message = message;
+        this.status = status;
+    }
+
+    // ErrorResponseDto로 변환
+    public ErrorResponseDto toErrorResponseDto() {
+        return new ErrorResponseDto(this.message, this.status);
+    }
+}

--- a/src/main/java/backend/yamukja/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/backend/yamukja/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package backend.yamukja.common.exception;
+
+import backend.yamukja.common.dto.ErrorResponseDto;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(GeneralException.class)
+    public ResponseEntity<ErrorResponseDto> handleGeneralException(GeneralException e) {
+        ErrorResponseDto errorResponse = e.toErrorResponseDto();
+        return new ResponseEntity<>(errorResponse, e.getStatus());
+    }
+}

--- a/src/main/java/backend/yamukja/user/constants/ErrorMessage.java
+++ b/src/main/java/backend/yamukja/user/constants/ErrorMessage.java
@@ -1,0 +1,10 @@
+package backend.yamukja.user.constants;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ErrorMessage {
+    public static final String ALREADY_JOINED_USER = "이미 존재하는 계정입니다.";
+}

--- a/src/main/java/backend/yamukja/user/controllers/UserController.java
+++ b/src/main/java/backend/yamukja/user/controllers/UserController.java
@@ -1,0 +1,29 @@
+package backend.yamukja.user.controllers;
+
+import backend.yamukja.user.dto.JoinRequestDto;
+import backend.yamukja.user.services.UserService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/user")
+public class UserController {
+
+    private final UserService userService;
+
+    @Autowired
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @PostMapping("/join")
+    public void join(@RequestBody JoinRequestDto request) {
+        log.info("회원가입 요청 ID: {}", request.getUserId());
+        userService.join(request);
+    }
+}

--- a/src/main/java/backend/yamukja/user/dto/JoinRequestDto.java
+++ b/src/main/java/backend/yamukja/user/dto/JoinRequestDto.java
@@ -1,0 +1,13 @@
+package backend.yamukja.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class JoinRequestDto {
+    private String userId;
+    private String password;
+}

--- a/src/main/java/backend/yamukja/user/entity/User.java
+++ b/src/main/java/backend/yamukja/user/entity/User.java
@@ -1,0 +1,31 @@
+package backend.yamukja.user.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Point;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(nullable = false)
+    private String userId;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(columnDefinition = "GEOMETRY")
+    private Point geography;
+
+    @Column(nullable = false)
+    private Boolean isLunchRecommend = false;
+}

--- a/src/main/java/backend/yamukja/user/entity/User.java
+++ b/src/main/java/backend/yamukja/user/entity/User.java
@@ -17,7 +17,7 @@ public class User {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
 
-    @Column(nullable = false)
+    @Column(unique = true, nullable = false) // unique 제약 조건 추가
     private String userId;
 
     @Column(nullable = false)

--- a/src/main/java/backend/yamukja/user/entity/User.java
+++ b/src/main/java/backend/yamukja/user/entity/User.java
@@ -27,5 +27,5 @@ public class User {
     private Point geography;
 
     @Column(nullable = false)
-    private Boolean isLunchRecommend = false;
+    private Boolean isLunchRecommend;
 }

--- a/src/main/java/backend/yamukja/user/repository/UserRepository.java
+++ b/src/main/java/backend/yamukja/user/repository/UserRepository.java
@@ -1,0 +1,8 @@
+package backend.yamukja.user.repository;
+
+import backend.yamukja.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, String> {
+    boolean existsByUserId(String userId);
+}

--- a/src/main/java/backend/yamukja/user/services/UserService.java
+++ b/src/main/java/backend/yamukja/user/services/UserService.java
@@ -1,0 +1,36 @@
+package backend.yamukja.user.services;
+
+import backend.yamukja.user.constants.ErrorMessage;
+import backend.yamukja.user.dto.JoinRequestDto;
+import backend.yamukja.user.entity.User;
+import backend.yamukja.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final BCryptPasswordEncoder encoder;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void join(JoinRequestDto request){
+        // 계정 중복 확인
+        if (userRepository.existsByUserId(request.getUserId())) {
+            throw new IllegalStateException(ErrorMessage.ALREADY_JOINED_USER);
+        }
+
+        // 유저 생성
+        User newUser = User.builder()
+                .userId(request.getUserId())
+                .password(encoder.encode(request.getPassword()))
+                .build();
+
+        userRepository.save(newUser);
+    }
+}

--- a/src/main/java/backend/yamukja/user/services/UserService.java
+++ b/src/main/java/backend/yamukja/user/services/UserService.java
@@ -29,6 +29,7 @@ public class UserService {
         User newUser = User.builder()
                 .userId(request.getUserId())
                 .password(encoder.encode(request.getPassword()))
+                .isLunchRecommend(false)
                 .build();
 
         userRepository.save(newUser);

--- a/src/main/java/backend/yamukja/user/services/UserService.java
+++ b/src/main/java/backend/yamukja/user/services/UserService.java
@@ -1,11 +1,13 @@
 package backend.yamukja.user.services;
 
+import backend.yamukja.common.exception.GeneralException;
 import backend.yamukja.user.constants.ErrorMessage;
 import backend.yamukja.user.dto.JoinRequestDto;
 import backend.yamukja.user.entity.User;
 import backend.yamukja.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -22,7 +24,7 @@ public class UserService {
     public void join(JoinRequestDto request){
         // 계정 중복 확인
         if (userRepository.existsByUserId(request.getUserId())) {
-            throw new IllegalStateException(ErrorMessage.ALREADY_JOINED_USER);
+            throw new GeneralException(ErrorMessage.ALREADY_JOINED_USER, HttpStatus.CONFLICT);
         }
 
         // 유저 생성


### PR DESCRIPTION
## 작업 내용
> 유저 entity 작성 및 회원가입 API 구현
> MySql의 GEOMETRY 타입으로 위치 저장
> 전역 예외처리기 작성

## 참고(선택)
> socialFeed 프로젝트에서 전역 예외처리기를 만들었지만 사용안한게 아쉬워서 
> 임시 도메인별 예외 처리 클래스를 구현했습니다.
```
{
    "message": "이미 존재하는 계정입니다.",
    "status": "CONFLICT"
}
```

### #️⃣이슈 번호
> #4 
