### PR TITLE
[FEAT] 로그인, 로그아웃, 토큰 재발급, JwtFilter 등 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,14 @@ dependencies {
     //DB
     implementation 'mysql:mysql-connector-java:8.0.30'
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // JWT
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/src/main/java/backend/yamukja/auth/constant/Constant.java
+++ b/src/main/java/backend/yamukja/auth/constant/Constant.java
@@ -1,0 +1,13 @@
+package backend.yamukja.auth.constant;
+
+public class Constant {
+    public static final String WRONG_USERNAME = "아이디를 확인해주세요";
+    public static final String WRONG_PASSWORD = "비밀번호를 확인해주세요";
+    public static final String NO_REFRESH_TOKEN = "리프레쉬 토큰이 포함되지 않았습니다";
+    public static final String REFRESH_TOKEN_NOT_FOUND = "저장된 리프레쉬 토큰이 없습니다";
+    public static final String ACCESS_TOKEN_EXPIRED = "액세스 토큰이 만료되었습니다. 재발급해주세요";
+    public static final String INVALID_ACCESS_TOKEN = "유효하지 않은 액세스 토큰입니다. 다시 로그인해주세요.";
+    public static final String UNEXPECTED_ERROR_OCCUR = "예기치 못한 오류가 발생했습니다. 잠시 뒤 다시 시도해주세요";
+    public static final String PLEASE_LOGIN = "로그인이 필요한 엔드포인트입니다.";
+    public static final String REFRESH_TOKEN_EXPIRED = "리프레쉬 토큰이 만료되었습니다. 다시 로그인해주세요.";
+}

--- a/src/main/java/backend/yamukja/auth/controller/AuthController.java
+++ b/src/main/java/backend/yamukja/auth/controller/AuthController.java
@@ -20,11 +20,6 @@ public class AuthController {
     private final AuthService authService;
     private static final String REFRESH_TOKEN_COOKIE_NAME = "REFRESH_TOKEN";
 
-    @GetMapping("/api/login/test")
-    public UserCustom test(@AuthenticationPrincipal UserCustom userCustom) {
-        return userCustom;
-    }
-
     /**
      * 로그인 엔드포인트
      *

--- a/src/main/java/backend/yamukja/auth/controller/AuthController.java
+++ b/src/main/java/backend/yamukja/auth/controller/AuthController.java
@@ -1,0 +1,98 @@
+package backend.yamukja.auth.controller;
+
+import backend.yamukja.auth.dto.AuthTokens;
+import backend.yamukja.auth.dto.LoginRequest;
+import backend.yamukja.auth.dto.LoginResponse;
+import backend.yamukja.auth.model.UserCustom;
+import backend.yamukja.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@Slf4j
+@RequiredArgsConstructor
+public class AuthController {
+    private final AuthService authService;
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "REFRESH_TOKEN";
+
+    @GetMapping("/api/login/test")
+    public UserCustom test(@AuthenticationPrincipal UserCustom userCustom) {
+        return userCustom;
+    }
+
+    /**
+     * 로그인 엔드포인트
+     *
+     * @param loginRequest username, password
+     * @return Access Token(15분 후 만료), Refresh token(3시간 후 만료)
+     */
+    @PostMapping("/api/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest loginRequest) {
+        // 로그인 서비스 호출
+        AuthTokens authTokens = authService.login(loginRequest);
+
+        // 쿠키에 Refresh token 담기
+        ResponseCookie refreshTokenCookie = getCookie(authTokens.getRefreshToken(), 4 * 60 * 60);
+
+        // HTTP 응답 헤더에 쿠키 추가
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return ResponseEntity.ok().headers(headers).body(authTokens.getLoginResponse());
+    }
+
+    /**
+     * Access Token 재발급
+     *
+     * @param refreshToken
+     * @return 새로운 Access Token
+     */
+    @PostMapping("/api/token/reissue")
+    public ResponseEntity<String> reissueToken(@CookieValue(name = REFRESH_TOKEN_COOKIE_NAME) String refreshToken) {
+        log.info("/api/token/reissue");
+        return ResponseEntity.ok().body(authService.reissueToken(refreshToken));
+    }
+
+    /**
+     * 로그아웃
+     * Redis/쿠키에서 Refresh Token 삭제
+     *
+     * @param refreshToken
+     * @return
+     */
+    @PostMapping("/api/logout")
+    public ResponseEntity<Void> logOut(@CookieValue(name = REFRESH_TOKEN_COOKIE_NAME) String refreshToken) {
+        // Redis에서 REFRESH_TOKEN 삭제
+        authService.logOut(refreshToken);
+
+        // 쿠키에서 REFRESH_TOKEN 삭제
+        ResponseCookie refreshTokenCookie = getCookie("", 0);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
+
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 쿠키 생성 메소드
+     *
+     * @param value  RefreshToken
+     * @param maxAge 유효 시간
+     * @return 쿠키 객체
+     */
+    private ResponseCookie getCookie(String value, long maxAge) {
+        return ResponseCookie.from(REFRESH_TOKEN_COOKIE_NAME, value)
+                .httpOnly(true)  // JavaScript에서 쿠키에 접근하지 못하게 설정
+                .path("/")       // 쿠키의 경로 설정
+                .secure(false) // HTTP 요청 허락
+                .maxAge(maxAge) // 유효시간
+                .sameSite("Strict") // SameSite 설정
+                .build();
+    }
+}

--- a/src/main/java/backend/yamukja/auth/dto/AuthTokens.java
+++ b/src/main/java/backend/yamukja/auth/dto/AuthTokens.java
@@ -1,0 +1,19 @@
+package backend.yamukja.auth.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * AuthController - AuthService 레이어 간 사용하는 DTO
+ */
+@Getter
+@ToString
+public class AuthTokens {
+    private String refreshToken;
+    private LoginResponse loginResponse;
+
+    public AuthTokens(String refreshToken, String accessToken, String username) {
+        this.refreshToken = refreshToken;
+        this.loginResponse = new LoginResponse(username, accessToken);
+    }
+}

--- a/src/main/java/backend/yamukja/auth/dto/LoginRequest.java
+++ b/src/main/java/backend/yamukja/auth/dto/LoginRequest.java
@@ -1,0 +1,14 @@
+package backend.yamukja.auth.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * 로그인 요청 DTO
+ */
+@Getter
+@ToString
+public class LoginRequest {
+    private String username;
+    private String password;
+}

--- a/src/main/java/backend/yamukja/auth/dto/LoginResponse.java
+++ b/src/main/java/backend/yamukja/auth/dto/LoginResponse.java
@@ -1,0 +1,16 @@
+package backend.yamukja.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * 로그인 성공 시 리턴할 DTO
+ */
+@AllArgsConstructor
+@Getter
+@ToString
+public class LoginResponse {
+    private String username;
+    private String accessToken;
+}

--- a/src/main/java/backend/yamukja/auth/filter/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/backend/yamukja/auth/filter/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,31 @@
+package backend.yamukja.auth.filter;
+
+import backend.yamukja.common.dto.ErrorResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static backend.yamukja.auth.constant.Constant.PLEASE_LOGIN;
+
+/**
+ * Spring Security 예외처리
+ */
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json; charset=UTF-8");
+
+        response.getWriter().write(objectMapper.writeValueAsString(new ErrorResponseDto(PLEASE_LOGIN, HttpStatus.UNAUTHORIZED)));
+    }
+}

--- a/src/main/java/backend/yamukja/auth/filter/JwtExceptionFilter.java
+++ b/src/main/java/backend/yamukja/auth/filter/JwtExceptionFilter.java
@@ -1,0 +1,61 @@
+package backend.yamukja.auth.filter;
+
+import backend.yamukja.common.dto.ErrorResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static backend.yamukja.auth.constant.Constant.*;
+
+/**
+ * JwtFilter에서 발생하는 예외처리용 필터
+ */
+@Component
+@Slf4j
+public class JwtExceptionFilter extends OncePerRequestFilter {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            // JWT 필터에서 발생한 예외처리
+            filterChain.doFilter(request, response);
+        } catch (ExpiredJwtException e) {
+            // Access Token 만료
+            setErrorResponse(response, ACCESS_TOKEN_EXPIRED);
+        } catch (JwtException | NumberFormatException e) {
+            // 유효하지 않은 JWT 토큰 도착
+            setErrorResponse(response, INVALID_ACCESS_TOKEN);
+        } catch (Exception e) {
+            e.printStackTrace();
+            setErrorResponse(response, UNEXPECTED_ERROR_OCCUR);
+        }
+    }
+
+    /**
+     * 예외 발생 시 응답 객체를 만드는 메소드
+     * (401 UNAUTHORIZED 리턴)
+     *
+     * @param response 응답
+     * @param message 예외 메시지
+     * @throws IOException
+     */
+    public void setErrorResponse(HttpServletResponse response, String message) throws IOException {
+        ErrorResponseDto errorResponse = new ErrorResponseDto(message, HttpStatus.UNAUTHORIZED);
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json; charset=UTF-8");
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/backend/yamukja/auth/filter/JwtFilter.java
+++ b/src/main/java/backend/yamukja/auth/filter/JwtFilter.java
@@ -1,0 +1,82 @@
+package backend.yamukja.auth.filter;
+
+import backend.yamukja.auth.service.TokenService;
+import backend.yamukja.auth.token.AccessToken;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * JWT 유효성 검사 필터
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtFilter extends OncePerRequestFilter {
+    public static final String AUTHORIZATION_HEADER = "Authorization";
+    public static final String BEARER_PREFIX = "Bearer ";
+    private final TokenService tokenService;
+
+    /**
+     *
+     * @param request
+     * @param response
+     * @param filterChain
+     * @throws ExpiredJwtException Access Token 유효시간 만료 시
+     * @throws JwtException MalformedJwtException 등 유효하지 않은 JWT가 들어왔을 떄
+     * @throws NumberFormatException Jwt Claim 내부 정보 형변환 과정에서 발생 가능
+     *
+     */
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        log.info("*** JWT FILTER: REQUEST URL: {}", request.getRequestURL());
+
+        // 헤더에서 Access Token 추출
+        String token = resolveToken(request);
+
+        if (token != null) {
+            log.info("token: {}", token);
+            // JWT -> Access Token 객체
+            AccessToken accessToken = tokenService.convertAccessToken(token);
+
+            // SecurityContext에 등록
+            setAuthenticationFromClaims(accessToken.getData());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * 헤더에서 token 추출
+     *
+     * @param request
+     * @return Authorization 헤더에 Bearer로 시작하는 토큰이 포함되어 왔을 때, 'Bearer' 떼고 반환
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length()).trim();
+        }
+
+        return null;
+    }
+
+    private void setAuthenticationFromClaims(Claims claims) {
+        Long userId = Long.valueOf(String.valueOf(claims.get("aud")));
+        String username = claims.getSubject();
+
+        tokenService.setAuthentication(userId, username);
+    }
+}

--- a/src/main/java/backend/yamukja/auth/model/ActiveUser.java
+++ b/src/main/java/backend/yamukja/auth/model/ActiveUser.java
@@ -1,0 +1,39 @@
+package backend.yamukja.auth.model;
+
+import backend.yamukja.auth.token.RefreshToken;
+import lombok.*;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.redis.core.RedisHash;
+
+import java.time.LocalDateTime;
+
+/**
+ * Redis 저장용 엔티티
+ */
+@Getter
+@RedisHash(value = "activeUser", timeToLive = 14400) // 4시간 저장
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ActiveUser {
+    @Id
+    private String refreshToken;
+
+    private LocalDateTime expiredAt; // 만료 시각
+
+    private Long id; // user pk
+
+    private String username;
+
+    private LocalDateTime createdAt;
+
+    public ActiveUser(Long id, String username, RefreshToken refreshToken) {
+        this.id = id;
+        this.username = username;
+
+        this.refreshToken = refreshToken.getToken();
+        this.expiredAt = refreshToken.getExpiredAt();
+
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/backend/yamukja/auth/model/UserCustom.java
+++ b/src/main/java/backend/yamukja/auth/model/UserCustom.java
@@ -1,0 +1,54 @@
+package backend.yamukja.auth.model;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+/**
+ * Custom UserDetails 객체
+ */
+@AllArgsConstructor
+@Getter
+public class UserCustom implements UserDetails {
+    private Long id; // pk
+    private String username;
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+}

--- a/src/main/java/backend/yamukja/auth/repository/ActiveUserRepository.java
+++ b/src/main/java/backend/yamukja/auth/repository/ActiveUserRepository.java
@@ -1,0 +1,12 @@
+package backend.yamukja.auth.repository;
+
+import backend.yamukja.auth.model.ActiveUser;
+import org.springframework.data.repository.Repository;
+
+import java.util.Optional;
+
+public interface ActiveUserRepository extends Repository<ActiveUser, String> {
+    ActiveUser save(ActiveUser activeUser);
+    Optional<ActiveUser> findById(String refreshToken);
+    void deleteById(String refreshToken);
+}

--- a/src/main/java/backend/yamukja/auth/service/AuthService.java
+++ b/src/main/java/backend/yamukja/auth/service/AuthService.java
@@ -1,0 +1,10 @@
+package backend.yamukja.auth.service;
+
+import backend.yamukja.auth.dto.AuthTokens;
+import backend.yamukja.auth.dto.LoginRequest;
+
+public interface AuthService {
+    AuthTokens login(LoginRequest loginRequest);
+    String reissueToken(String refreshToken);
+    void logOut(String refreshToken);
+}

--- a/src/main/java/backend/yamukja/auth/service/AuthServiceImpl.java
+++ b/src/main/java/backend/yamukja/auth/service/AuthServiceImpl.java
@@ -1,0 +1,66 @@
+package backend.yamukja.auth.service;
+
+import backend.yamukja.auth.dto.AuthTokens;
+import backend.yamukja.auth.dto.LoginRequest;
+import backend.yamukja.auth.token.AccessToken;
+import backend.yamukja.auth.token.RefreshToken;
+import backend.yamukja.common.exception.RefreshTokenException;
+import backend.yamukja.user.entity.User;
+import backend.yamukja.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+import java.util.NoSuchElementException;
+
+import static backend.yamukja.auth.constant.Constant.*;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+    private final TokenService tokenService;
+    private final BCryptPasswordEncoder passwordEncoder;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional(readOnly = true)
+    public AuthTokens login(LoginRequest loginRequest) {
+        User user = userRepository.findByUserId(loginRequest.getUsername())
+                .orElseThrow(() -> new NoSuchElementException(WRONG_USERNAME));
+
+        // 비밀번호 일치 여부 확인
+        if (!passwordEncoder.matches(loginRequest.getPassword(), user.getPassword())) {
+            throw new BadCredentialsException(WRONG_PASSWORD);
+        }
+
+        // Security Context 저장
+        tokenService.setAuthentication(user.getId(), user.getUserId());
+
+        // Access Token, Refresh Token 생성
+        AccessToken accessToken = tokenService.generateAccessToken(user.getId(), user.getUserId());
+        RefreshToken refreshToken = tokenService.generateRefreshToken(user.getId(), user.getUserId());
+
+        return new AuthTokens(refreshToken.getToken(), accessToken.getToken(), user.getUserId());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public String reissueToken(String refreshToken) {
+        return tokenService.refreshAccessToken(refreshToken).getToken();
+    }
+
+    @Override
+    @Transactional
+    public void logOut(String refreshToken) {
+        if(!StringUtils.hasText(refreshToken)) {
+            throw new RefreshTokenException(NO_REFRESH_TOKEN);
+        }
+
+        tokenService.deleteRefreshToken(refreshToken);
+    }
+}

--- a/src/main/java/backend/yamukja/auth/service/TokenService.java
+++ b/src/main/java/backend/yamukja/auth/service/TokenService.java
@@ -1,0 +1,13 @@
+package backend.yamukja.auth.service;
+
+import backend.yamukja.auth.token.AccessToken;
+import backend.yamukja.auth.token.RefreshToken;
+
+public interface TokenService {
+    AccessToken convertAccessToken(String token);
+    void setAuthentication(Long userId, String username);
+    AccessToken generateAccessToken(Long userId, String username);
+    RefreshToken generateRefreshToken(Long userId, String username);
+    AccessToken refreshAccessToken(String refreshToken);
+    void deleteRefreshToken(String refreshToken);
+}

--- a/src/main/java/backend/yamukja/auth/service/TokenServiceImpl.java
+++ b/src/main/java/backend/yamukja/auth/service/TokenServiceImpl.java
@@ -1,0 +1,86 @@
+package backend.yamukja.auth.service;
+
+import backend.yamukja.auth.model.ActiveUser;
+import backend.yamukja.auth.model.UserCustom;
+import backend.yamukja.auth.repository.ActiveUserRepository;
+import backend.yamukja.auth.token.AccessToken;
+import backend.yamukja.auth.token.RefreshToken;
+import backend.yamukja.common.exception.RefreshTokenException;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.NoSuchElementException;
+
+import static backend.yamukja.auth.constant.Constant.REFRESH_TOKEN_EXPIRED;
+import static backend.yamukja.auth.constant.Constant.REFRESH_TOKEN_NOT_FOUND;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TokenServiceImpl implements TokenService {
+    private final ActiveUserRepository activeUserRepository;
+    @Value("${secret}")
+    private String secret;
+    private Key key;
+
+    @PostConstruct
+    public void init() {
+        this.key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+    }
+
+    @Override
+    public AccessToken convertAccessToken(String token) {
+        return new AccessToken(token, key);
+    }
+
+    @Override
+    public void setAuthentication(Long userId, String username) {
+        UserCustom userCustom = new UserCustom(userId, username);
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(userCustom, null, Collections.singleton(new SimpleGrantedAuthority("USER")));
+        SecurityContextHolder.getContext().setAuthentication(token);
+    }
+
+    @Override
+    public AccessToken generateAccessToken(Long userId, String username) {
+        return new AccessToken(userId, username, key);
+    }
+
+    @Override
+    public RefreshToken generateRefreshToken(Long userId, String username) {
+        RefreshToken refreshToken = new RefreshToken();
+
+        // Refresh token Redis에 저장
+        ActiveUser activeUser = new ActiveUser(userId, username, refreshToken);
+        activeUserRepository.save(activeUser);
+
+        return refreshToken;
+    }
+
+    public AccessToken refreshAccessToken(String refreshToken) {
+        ActiveUser activeUser = activeUserRepository.findById(refreshToken)
+                .orElseThrow(() -> new NoSuchElementException(REFRESH_TOKEN_NOT_FOUND));
+
+        if (activeUser.getExpiredAt().isBefore(LocalDateTime.now())) {
+            // refresh token 만료
+            activeUserRepository.deleteById(refreshToken); // Redis에서 삭제
+            throw new RefreshTokenException(REFRESH_TOKEN_EXPIRED);
+        }
+
+        return generateAccessToken(activeUser.getId(), activeUser.getUsername());
+    }
+
+    public void deleteRefreshToken(String refreshToken) {
+        activeUserRepository.deleteById(refreshToken);
+    }
+}

--- a/src/main/java/backend/yamukja/auth/token/AccessToken.java
+++ b/src/main/java/backend/yamukja/auth/token/AccessToken.java
@@ -1,0 +1,76 @@
+package backend.yamukja.auth.token;
+
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.security.Key;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Getter
+@ToString
+public class AccessToken {
+    // 만료 시간(분)
+    public static final int EXPIRED_AFTER = 15; // 15분
+
+    // 암호화된 token
+    private final String token;
+
+    // key
+    private final Key key;
+
+    // 만료 일자
+    private LocalDateTime expiredAt;
+
+    // AccessToken 생성자 (발급 시)
+    // User가 아니라 UserPrincipal로 만들도록 수정
+    public AccessToken(Long id, String username, Key key) {
+        LocalDateTime expiredAt = LocalDateTime.now().plusMinutes(EXPIRED_AFTER);
+        Date expiredDate = Date.from(expiredAt.atZone(ZoneId.systemDefault()).toInstant());
+
+        // claims 만들기
+        Map<String, Object> claims = new HashMap<>();
+
+        claims.put("iss", "skeleton"); // 발행인
+        claims.put("aud", id); // 토큰 대상자(User PK)
+        claims.put("exp", LocalDateTime.now().toString()); // 발행 시간
+
+        this.key = key;
+        this.expiredAt = expiredAt;
+        this.token = createJwtAuthToken(username, claims, expiredDate);
+    }
+
+    // JWT로 만드는 메소드
+    public String createJwtAuthToken(String username, Map<String, Object> claimMap, Date expiredDate) {
+        return Jwts.builder()
+                .setSubject(username)
+                .addClaims(claimMap)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .setExpiration(expiredDate)
+                .compact();
+    }
+
+    // 이하는 AccessToken 유효성 검증에 사용
+    public AccessToken(String token, Key key) {
+        this.token = token;
+        this.key = key;
+    }
+
+    // JWT 디코딩
+    public Claims getData() {
+        return Jwts
+                .parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/src/main/java/backend/yamukja/auth/token/RefreshToken.java
+++ b/src/main/java/backend/yamukja/auth/token/RefreshToken.java
@@ -1,0 +1,25 @@
+package backend.yamukja.auth.token;
+
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/**
+ * Refresh Token (3시간 뒤 만료)
+ */
+@Getter
+public class RefreshToken {
+    private String token;
+    private LocalDateTime expiredAt;
+
+    public RefreshToken() {
+        this.token = UUID.randomUUID().toString();
+        this.expiredAt = LocalDateTime.now().plusHours(3);
+    }
+
+    public RefreshToken(String token, LocalDateTime expiredAt) {
+        this.token = token;
+        this.expiredAt = expiredAt;
+    }
+}

--- a/src/main/java/backend/yamukja/common/config/SecurityConfig.java
+++ b/src/main/java/backend/yamukja/common/config/SecurityConfig.java
@@ -1,20 +1,40 @@
 package backend.yamukja.common.config;
 
+import backend.yamukja.auth.filter.JwtExceptionFilter;
+import backend.yamukja.auth.filter.JwtFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HttpBasicConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtFilter jwtFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
+    private final AuthenticationEntryPoint authenticationEntryPoint;
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf(csrf -> csrf.disable())
+        http
+                .httpBasic(HttpBasicConfigurer::disable)
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
                 .authorizeHttpRequests((requests) -> requests
-                        .requestMatchers("/api/user/join").permitAll()  // 회원가입 접근 허용
+                        .requestMatchers("/api/login", "/api/register", "/api/token/reissue", "/api/logout").permitAll()
                         .anyRequest().authenticated()  // 그 외 요청은 인증 필요
-                );
+                )
+                .exceptionHandling(e -> e.authenticationEntryPoint(authenticationEntryPoint))
+                .addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtFilter.class);
 
         return http.build();
     }

--- a/src/main/java/backend/yamukja/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/backend/yamukja/common/exception/GlobalExceptionHandler.java
@@ -1,15 +1,45 @@
 package backend.yamukja.common.exception;
 
 import backend.yamukja.common.dto.ErrorResponseDto;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@ControllerAdvice
+import java.util.NoSuchElementException;
+
+@RestControllerAdvice
 public class GlobalExceptionHandler {
     @ExceptionHandler(GeneralException.class)
     public ResponseEntity<ErrorResponseDto> handleGeneralException(GeneralException e) {
         ErrorResponseDto errorResponse = e.toErrorResponseDto();
         return new ResponseEntity<>(errorResponse, e.getStatus());
+    }
+
+    @ExceptionHandler(RefreshTokenException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ErrorResponseDto handleRefreshTokenException(RefreshTokenException e) {
+        return new ErrorResponseDto(e.getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(UsernameNotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponseDto handleUsernameNotFoundException(UsernameNotFoundException e) {
+        return new ErrorResponseDto(e.getMessage(), HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(BadCredentialsException.class)
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    public ErrorResponseDto handleBadCredentialsException(BadCredentialsException e) {
+        return new ErrorResponseDto(e.getMessage(), HttpStatus.UNAUTHORIZED);
+    }
+
+    @ExceptionHandler(NoSuchElementException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ErrorResponseDto handleNoSuchElementException(NoSuchElementException e) {
+        return new ErrorResponseDto(e.getMessage(), HttpStatus.NOT_FOUND);
     }
 }

--- a/src/main/java/backend/yamukja/common/exception/RefreshTokenException.java
+++ b/src/main/java/backend/yamukja/common/exception/RefreshTokenException.java
@@ -1,0 +1,10 @@
+package backend.yamukja.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class RefreshTokenException extends RuntimeException {
+    private String message;
+}

--- a/src/main/java/backend/yamukja/user/repository/UserRepository.java
+++ b/src/main/java/backend/yamukja/user/repository/UserRepository.java
@@ -3,6 +3,10 @@ package backend.yamukja.user.repository;
 import backend.yamukja.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<User, String> {
+import java.util.Optional;
+
+
+public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUserId(String userId);
+    Optional<User> findByUserId(String userId);
 }


### PR DESCRIPTION
## 작업 내용
> 로그인, 로그아웃, 토큰 재발급 엔드포인트 완성
> AccessToken, RefreshToken 생성 및 저장
> JWT 유효성 검사 필터, 예외처리 필터
> 예외처리





### #️⃣이슈 번호
> #10 


