### PR TITLE
[FEAT]B_OPENAPI_02 - API 추가 및 스케줄링 자동화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    //Quartz Scheduling
+    implementation 'org.springframework.boot:spring-boot-starter-quartz'
 }
 
 tasks.named('test') {

--- a/src/main/java/backend/yamukja/YaMukJaApplication.java
+++ b/src/main/java/backend/yamukja/YaMukJaApplication.java
@@ -2,7 +2,9 @@ package backend.yamukja;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class YaMukJaApplication {
 

--- a/src/main/java/backend/yamukja/common/config/CustomSpringBeanJobFactory.java
+++ b/src/main/java/backend/yamukja/common/config/CustomSpringBeanJobFactory.java
@@ -1,0 +1,26 @@
+package backend.yamukja.common.config;
+
+import org.quartz.spi.TriggerFiredBundle;
+import org.springframework.beans.factory.config.AutowireCapableBeanFactory;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.scheduling.quartz.SpringBeanJobFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomSpringBeanJobFactory extends SpringBeanJobFactory implements ApplicationContextAware {
+
+    private AutowireCapableBeanFactory beanFactory;
+
+    @Override
+    public void setApplicationContext(final ApplicationContext context) {
+        this.beanFactory = context.getAutowireCapableBeanFactory();
+    }
+
+    @Override
+    protected Object createJobInstance(final TriggerFiredBundle bundle) throws Exception {
+        final Object job = super.createJobInstance(bundle);
+        this.beanFactory.autowireBean(job);
+        return job;
+    }
+}

--- a/src/main/java/backend/yamukja/common/config/QuartzSchedulerConfig.java
+++ b/src/main/java/backend/yamukja/common/config/QuartzSchedulerConfig.java
@@ -1,0 +1,78 @@
+package backend.yamukja.common.config;
+
+import backend.yamukja.place.constant.Constants;
+import backend.yamukja.place.job.PlaceJob;
+import lombok.RequiredArgsConstructor;
+import org.quartz.*;
+import org.springframework.boot.autoconfigure.quartz.QuartzProperties;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.quartz.SchedulerFactoryBean;
+
+import java.util.Properties;
+
+@Configuration
+@RequiredArgsConstructor
+public class QuartzSchedulerConfig {
+
+    private final CustomSpringBeanJobFactory jobFactory;
+    private final QuartzProperties quartzProperties;
+
+    @Bean
+    public JobDetail placeJobDetail() {
+        return JobBuilder.newJob(PlaceJob.class)
+                .withIdentity("placeJobDetail", "group1")
+                .storeDurably()
+                .build();
+    }
+
+    /**
+     * 매일 오전 6시에 Quartz Scheduler 가 시작됩니다.
+     * @param url
+     * @param apiName
+     * @param intervalInSeconds
+     * @return
+     */
+    private Trigger createTrigger(String url, String apiName, int intervalInSeconds) {
+        String cronExpression = "0 0 6 * * ?";
+
+        return TriggerBuilder.newTrigger()
+                .forJob(placeJobDetail())
+                .withIdentity("placeJobTrigger_" + apiName, "group1")
+                .withSchedule(CronScheduleBuilder.cronSchedule(cronExpression))
+                .usingJobData("url", url)
+                .usingJobData("apiName", apiName)
+                .build();
+    }
+
+    @Bean
+    public SchedulerFactoryBean schedulerFactoryBean(ApplicationContext applicationContext) {
+        SchedulerFactoryBean schedulerFactoryBean = new SchedulerFactoryBean();
+        Properties properties = new Properties();
+        properties.putAll(quartzProperties.getProperties());
+
+        schedulerFactoryBean.setJobFactory(jobFactory);
+        schedulerFactoryBean.setQuartzProperties(properties);
+        schedulerFactoryBean.setOverwriteExistingJobs(true);
+        schedulerFactoryBean.setWaitForJobsToCompleteOnShutdown(true);
+
+        // 각 URL에 대한 트리거를 생성하고 추가합니다.
+        Trigger chineseTrigger = createTrigger(Constants.CHINESE_URL_TEMPLATE, "Chinese", 10);
+        Trigger japaneseTrigger = createTrigger(Constants.JAPANESE_URL_TEMPLATE, "Japanese", 10);
+        Trigger fastFoodTrigger = createTrigger(Constants.FASTFOOD_URL_TEMPLATE, "Fastfood", 10);
+
+        schedulerFactoryBean.setJobDetails(placeJobDetail());
+        schedulerFactoryBean.setTriggers(chineseTrigger, japaneseTrigger, fastFoodTrigger);
+
+        return schedulerFactoryBean;
+    }
+
+    @Bean
+    public Scheduler scheduler(SchedulerFactoryBean schedulerFactoryBean) throws Exception {
+        Scheduler scheduler = schedulerFactoryBean.getScheduler();
+        scheduler.start(); // 스케줄러를 시작합니다.
+        return scheduler;
+    }
+}
+

--- a/src/main/java/backend/yamukja/common/config/RedisConfig.java
+++ b/src/main/java/backend/yamukja/common/config/RedisConfig.java
@@ -1,0 +1,35 @@
+package backend.yamukja.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableRedisRepositories
+public class RedisConfig {
+
+    private final RedisProperties redisProperties;
+
+    // lettuce
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+    }
+
+    // Redis template
+    @Bean
+    public RedisTemplate<?, ?> redisTemplate() {
+        RedisTemplate<?, ?> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());   //connection
+        redisTemplate.setKeySerializer(new StringRedisSerializer());    // key
+        redisTemplate.setValueSerializer(new StringRedisSerializer());  // value
+        return redisTemplate;
+    }
+}

--- a/src/main/java/backend/yamukja/common/constant/RedisConstants.java
+++ b/src/main/java/backend/yamukja/common/constant/RedisConstants.java
@@ -1,0 +1,10 @@
+package backend.yamukja.common.constant;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class RedisConstants {
+    public static final String API_NAME = "API_NAME:";
+    public static final String CURRENT_INDEX_FIELD = "currentIndex";
+    public static final String TOTAL_COUNT_FIELD = "totalCount";
+}

--- a/src/main/java/backend/yamukja/common/service/RedisService.java
+++ b/src/main/java/backend/yamukja/common/service/RedisService.java
@@ -1,0 +1,44 @@
+package backend.yamukja.common.service;
+
+
+import backend.yamukja.common.constant.RedisConstants;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.HashOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private HashOperations<String, String, String> hashOperations;
+
+    @PostConstruct
+    private void init() {
+        this.hashOperations = redisTemplate.opsForHash();
+    }
+
+    public void pushApiState(String apiName, int totalCount) {
+        String apiKey = RedisConstants.API_NAME + apiName;
+        hashOperations.put(apiKey, RedisConstants.CURRENT_INDEX_FIELD, String.valueOf(1));
+        hashOperations.put(apiKey, RedisConstants.TOTAL_COUNT_FIELD, String.valueOf(totalCount));
+    }
+
+    public int getCurrentIndex(String apiName) {
+        String apiKey = RedisConstants.API_NAME + apiName;
+        String currentIndexStr = hashOperations.get(apiKey, RedisConstants.CURRENT_INDEX_FIELD);
+        return currentIndexStr != null ? Integer.parseInt(currentIndexStr) : 1;
+    }
+
+    public int getTotalCount(String apiName) {
+        String apiKey = RedisConstants.API_NAME + apiName;
+        String totalCountStr = hashOperations.get(apiKey, RedisConstants.TOTAL_COUNT_FIELD);
+        return totalCountStr != null ? Integer.parseInt(totalCountStr) : 0;
+    }
+
+    public void setCurrentIndex(String apiName, Integer currentIndex) {
+        hashOperations.put(RedisConstants.API_NAME + apiName, "currentIndex", String.valueOf(currentIndex));
+    }
+}

--- a/src/main/java/backend/yamukja/common/service/SchedulerStatus.java
+++ b/src/main/java/backend/yamukja/common/service/SchedulerStatus.java
@@ -1,0 +1,23 @@
+package backend.yamukja.common.service;
+
+import jakarta.annotation.PostConstruct;
+import org.quartz.Scheduler;
+import org.quartz.SchedulerException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SchedulerStatus {
+
+    @Autowired
+    private Scheduler scheduler;
+
+    @PostConstruct
+    public void checkSchedulerStatus() throws SchedulerException {
+        if (scheduler.isStarted()) {
+            System.out.println("-- Scheduler is RUNNING --");
+        } else {
+            System.out.println("-- Scheduler is NOT RUNNING --");
+        }
+    }
+}

--- a/src/main/java/backend/yamukja/place/constant/Constants.java
+++ b/src/main/java/backend/yamukja/place/constant/Constants.java
@@ -2,10 +2,23 @@ package backend.yamukja.place.constant;
 
 import lombok.experimental.UtilityClass;
 
+import java.util.Map;
+
 @UtilityClass
 public class Constants {
     public static final String API_REQUEST_INFO_MISSING = "필수 값이 누락되어 있습니다. 요청인자를 참고 하십시오.";
     public static final String API_KEY_INVALID = "인증키가 유효하지 않습니다. 인증키가 없는 경우, 홈페이지에서 인증키를 신청하십시오.";
     public static final String SQL_PARSE_ERROR = "SQL 문장 오류 입니다. 지속적으로 발생시 홈페이지로 문의(Q&A) 바랍니다.";
     public static final String ORDER_VALUE_ERROR = "잘못된 정렬 방법입니다. 거리순 또는 평점순으로 요청하세요.";
+    public static final String CHINESE_URL_TEMPLATE = "https://openapi.gg.go.kr/Genrestrtchifood";
+
+    public static final String FASTFOOD_URL_TEMPLATE = "https://openapi.gg.go.kr/Genrestrtfastfood";
+
+    public static final String JAPANESE_URL_TEMPLATE = "https://openapi.gg.go.kr/Genrestrtjpnfood";
+
+    public static final Map<String, String[]> URL_INFO_MAP = Map.of(
+            CHINESE_URL_TEMPLATE, new String[]{"Genrestrtchifood", "Chinese"},
+            FASTFOOD_URL_TEMPLATE, new String[]{"Genrestrtfastfood", "Fastfood"},
+            JAPANESE_URL_TEMPLATE, new String[]{"Genrestrtjpnfood", "Japanese"}
+    );
 }

--- a/src/main/java/backend/yamukja/place/controller/PlaceController.java
+++ b/src/main/java/backend/yamukja/place/controller/PlaceController.java
@@ -1,13 +1,17 @@
 package backend.yamukja.place.controller;
 
+import backend.yamukja.common.service.RedisService;
+import backend.yamukja.place.constant.Constants;
 import backend.yamukja.place.model.Place;
 import backend.yamukja.place.service.MappingService;
 import backend.yamukja.place.service.PlaceService;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.client.RestTemplate;
@@ -15,6 +19,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.List;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 public class PlaceController {
@@ -22,27 +27,40 @@ public class PlaceController {
     private final MappingService mappingService;
     private final RestTemplate restTemplate;
     private final PlaceService placeService;
+    private final RedisService redisService;
 
 
     @Value("${open.api.key}")
     private String key;
 
-    private static final String URL_TEMPLATE = "https://openapi.gg.go.kr/Genrestrtchifood";
     private static final String TYPE = "json"; // 호출 문서 타입
-    private static final int PAGE_SIZE = 10;
 
-    @GetMapping("/api/place-info")
+    /**
+     * quartz scheduler 에서 사용하는 api 로 자동화를 위해 url param 을 추가하였습니다.
+     * @param pSize
+     * @param sigunNm
+     * @param sigunCd
+     * @param url
+     * @return
+     */
+    @PostMapping("/api/place-info")
     public List<Place> getFoodInfo(
-            @RequestParam(value = "pIndex", defaultValue = "1") int pIndex,
             @RequestParam(value = "pSize", defaultValue = "100") int pSize,
             @RequestParam(value = "SIGUN_NM", required = false) String sigunNm,
-            @RequestParam(value = "SIGUN_CD", required = false) String sigunCd) {
+            @RequestParam(value = "SIGUN_CD", required = false) String sigunCd,
+            @RequestParam(value = "url") String url) {
 
-        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(URL_TEMPLATE)
+        // Redis에서 현재 페이지 번호를 나타내는 pIndex 가져오기
+        String[] info = Constants.URL_INFO_MAP.get(url);
+        int currentIndex = redisService.getCurrentIndex(info[1]);
+        log.info("URL :: {} place-info current INDEX :: {}", url, currentIndex);
+
+        // URI 빌드
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(url)
                 .queryParam("Key", key)
                 .queryParam("Type", TYPE)
-                .queryParam("pIndex", pIndex)
-                .queryParam("pSize", PAGE_SIZE);
+                .queryParam("pIndex", currentIndex)
+                .queryParam("pSize", pSize);
 
         if (sigunNm != null && !sigunNm.isEmpty()) {
             uriBuilder.queryParam("SIGUN_NM", sigunNm);
@@ -51,9 +69,14 @@ public class PlaceController {
             uriBuilder.queryParam("SIGUN_CD", sigunCd);
         }
 
+        // RestTemplate을 사용하여 API 요청 보내기
         ResponseEntity<String> response = restTemplate.getForEntity(uriBuilder.toUriString(), String.class);
-        List<Place> places = mappingService.parseJsonResponse(response.getBody());
+        List<Place> places = mappingService.parseJsonResponse(response.getBody(), url);
 
+        // 현재 pIndex를 증가시키고 Redis에 업데이트
+        redisService.setCurrentIndex(info[1], currentIndex + 1);
+
+        // API 응답 반환
         return places;
     }
 
@@ -66,4 +89,110 @@ public class PlaceController {
     ) {
         return placeService.getPlaceList(lat, lon, range, order);
     }
+
+    /**
+     * 수동으로 경기도_일반음식점(중국식) 현황 자료 데이터를 저장하는 api 입니다.
+     * /api/chinese-info default 로 api 요청하시면 1번째 페이지의 100개의 데이터가 저장됩니다.
+     * @param pSize
+     * @param pIndex
+     * @param sigunNm 시군명
+     * @param sigunCd 시군코드
+     * @return
+     */
+    @PostMapping("/api/chinese-info")
+    public List<Place> getChinesePlaceInfo(
+            @RequestParam(value = "pSize", defaultValue = "100") int pSize,
+            @RequestParam(value = "pIndex", defaultValue = "1") int pIndex,
+            @RequestParam(value = "SIGUN_NM", required = false) String sigunNm,
+            @RequestParam(value = "SIGUN_CD", required = false) String sigunCd) {
+
+        // URI 빌드
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(Constants.CHINESE_URL_TEMPLATE)
+                .queryParam("Key", key)
+                .queryParam("Type", TYPE)
+                .queryParam("pIndex", pIndex)
+                .queryParam("pSize", pSize);
+
+        if (sigunNm != null && !sigunNm.isEmpty()) {
+            uriBuilder.queryParam("SIGUN_NM", sigunNm);
+        }
+        if (sigunCd != null && !sigunCd.isEmpty()) {
+            uriBuilder.queryParam("SIGUN_CD", sigunCd);
+        }
+
+        // RestTemplate을 사용하여 API 요청 보내기
+        ResponseEntity<String> response = restTemplate.getForEntity(uriBuilder.toUriString(), String.class);
+        return mappingService.parseJsonResponse(response.getBody(), Constants.CHINESE_URL_TEMPLATE);
+    }
+
+    /**
+     * 수동으로 경기도_일반음식점(일식) 현황 자료 데이터를 저장하는 api 입니다.
+     * /api/japanese-info default 로 api 요청하시면 1번째 페이지의 100개의 데이터가 저장됩니다.
+     * @param pSize
+     * @param pIndex
+     * @param sigunNm 시군명
+     * @param sigunCd 시군코드
+     * @return
+     */
+    @PostMapping("/api/japanese-info")
+    public List<Place> getJapanesePlaceInfo(
+            @RequestParam(value = "pSize", defaultValue = "100") int pSize,
+            @RequestParam(value = "pIndex", defaultValue = "1") int pIndex,
+            @RequestParam(value = "SIGUN_NM", required = false) String sigunNm,
+            @RequestParam(value = "SIGUN_CD", required = false) String sigunCd) {
+
+        // URI 빌드
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(Constants.JAPANESE_URL_TEMPLATE)
+                .queryParam("Key", key)
+                .queryParam("Type", TYPE)
+                .queryParam("pIndex", pIndex)
+                .queryParam("pSize", pSize);
+
+        if (sigunNm != null && !sigunNm.isEmpty()) {
+            uriBuilder.queryParam("SIGUN_NM", sigunNm);
+        }
+        if (sigunCd != null && !sigunCd.isEmpty()) {
+            uriBuilder.queryParam("SIGUN_CD", sigunCd);
+        }
+
+        // RestTemplate을 사용하여 API 요청 보내기
+        ResponseEntity<String> response = restTemplate.getForEntity(uriBuilder.toUriString(), String.class);
+        return mappingService.parseJsonResponse(response.getBody(),Constants.JAPANESE_URL_TEMPLATE);
+    }
+
+    /**
+     * 수동으로 경기도_일반음식점(패스트푸드) 현황 자료 데이터를 저장하는 api 입니다.
+     * /api/fastfood-info default 로 api 요청하시면 1번째 페이지의 100개의 데이터가 저장됩니다.
+     * @param pSize
+     * @param pIndex
+     * @param sigunNm 시군명
+     * @param sigunCd 시군코드
+     * @return
+     */
+    @PostMapping("/api/fastfood-info")
+    public List<Place> getFastfoodPlaceInfo(
+            @RequestParam(value = "pSize", defaultValue = "100") int pSize,
+            @RequestParam(value = "pIndex", defaultValue = "1") int pIndex,
+            @RequestParam(value = "SIGUN_NM", required = false) String sigunNm,
+            @RequestParam(value = "SIGUN_CD", required = false) String sigunCd) {
+
+        // URI 빌드
+        UriComponentsBuilder uriBuilder = UriComponentsBuilder.fromHttpUrl(Constants.FASTFOOD_URL_TEMPLATE)
+                .queryParam("Key", key)
+                .queryParam("Type", TYPE)
+                .queryParam("pIndex", pIndex)
+                .queryParam("pSize", pSize);
+
+        if (sigunNm != null && !sigunNm.isEmpty()) {
+            uriBuilder.queryParam("SIGUN_NM", sigunNm);
+        }
+        if (sigunCd != null && !sigunCd.isEmpty()) {
+            uriBuilder.queryParam("SIGUN_CD", sigunCd);
+        }
+
+        // RestTemplate을 사용하여 API 요청 보내기
+        ResponseEntity<String> response = restTemplate.getForEntity(uriBuilder.toUriString(), String.class);
+        return mappingService.parseJsonResponse(response.getBody(), Constants.FASTFOOD_URL_TEMPLATE);
+    }
+
 }

--- a/src/main/java/backend/yamukja/place/job/PlaceJob.java
+++ b/src/main/java/backend/yamukja/place/job/PlaceJob.java
@@ -1,0 +1,67 @@
+package backend.yamukja.place.job;
+
+import backend.yamukja.common.service.RedisService;
+import backend.yamukja.place.constant.Constants;
+import backend.yamukja.place.controller.PlaceController;
+import backend.yamukja.place.model.Place;
+import lombok.extern.slf4j.Slf4j;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class PlaceJob implements Job {
+
+    @Autowired
+    private PlaceController placeController;
+
+    @Autowired
+    private RedisService redisService;
+
+    @Override
+    public void execute(JobExecutionContext jobExecutionContext) throws JobExecutionException {
+        String[] urls = {
+                Constants.CHINESE_URL_TEMPLATE,
+                Constants.JAPANESE_URL_TEMPLATE,
+                Constants.FASTFOOD_URL_TEMPLATE
+        };
+
+        for (String url : urls) {
+            boolean shouldContinue = true;
+
+            while (shouldContinue) {
+                List<Place> places = placeController.getFoodInfo(100, null, null, url);
+                log.info("Quartz scheduler [ {} ] places size :: {}", url, places.size());
+
+                // Redis에서 현재 page index 상태를 가져옵니다
+                String[] info = Constants.URL_INFO_MAP.get(url);
+                int currentIndex = redisService.getCurrentIndex(info[1]);
+                int totalCount = redisService.getTotalCount(info[1]);
+
+                // 총 페이지 수 계산
+                int totalPages = (int) Math.ceil((double) totalCount / 100);
+
+                // 현재 인덱스가 총 페이지 수를 초과하면 다음 URL로 넘어갑니다.
+                if (currentIndex >= totalPages) {
+                    shouldContinue = false;
+                }
+
+                // 다음 실행 전 대기 (10초 간격)
+                try {
+                    Thread.sleep(10000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new JobExecutionException(e);
+                }
+            }
+
+        }
+    }
+
+}
+

--- a/src/main/java/backend/yamukja/place/service/PlaceService.java
+++ b/src/main/java/backend/yamukja/place/service/PlaceService.java
@@ -4,7 +4,6 @@ import backend.yamukja.place.constant.Constants;
 import backend.yamukja.place.model.Place;
 import backend.yamukja.place.repository.PlaceRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,7 +24,15 @@ public class PlaceService {
 
     @Transactional
     public void saveAllList(List<Place> places) {
-        placeRepository.saveAll(places);
+        List<Place> uniquePlaces = new ArrayList<>();
+
+        for (Place place : places) {
+            if (!placeRepository.existsById(place.getId())) {
+                uniquePlaces.add(place);
+            }
+        }
+
+        placeRepository.saveAll(uniquePlaces);
     }
 
     /**


### PR DESCRIPTION
## 작업 내용
> 오전 6시마다 경기도_일반음식점 중국식, 일식, 패스트푸드점 open API 의 모든 데이터를 저장합니다.
> 해당 api 를 통해 각각의 api 에 대해 직접 데이터를 저장할 수 있습니다.
POST /api/japanese-info
POST /api/chinese-info
POST /api/fastfood-info

추후 테스트코드와 함께 기능 개선할 부분 있으면 리팩토링 진행하겠습니다

## 참고(선택)
> quartz 관련한 환경변수 어플리케이션 구동 전 꼭 추가해주세요 ~
```
spring:
  datasource:
    driver-class-name: com.mysql.cj.jdbc.Driver
    url: 
    username: 
    password: 
  jpa:
    hibernate:
      ddl-auto: update
  redis:
    host: 
    port: 16379
  quartz:
    job-store-type: jdbc
    jdbc:
      initialize-schema: always
    properties:
      org:
        quartz:
          threadPool:
            threadCount: 1

open:
  api:
    key: 

secret: 
```



### #️⃣이슈 번호
> #6 


