### PR TITLE
[Test] 테스트용 사용자 인증정보 모킹 어노테이션, 인증/사용자 상세 정보 테스트코드 구현 

### DIFF
--- a/src/main/java/backend/yamukja/auth/controller/AuthController.java
+++ b/src/main/java/backend/yamukja/auth/controller/AuthController.java
@@ -71,7 +71,7 @@ public class AuthController {
         HttpHeaders headers = new HttpHeaders();
         headers.add(HttpHeaders.SET_COOKIE, refreshTokenCookie.toString());
 
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.noContent().headers(headers).build();
     }
 
     /**

--- a/src/main/java/backend/yamukja/auth/dto/LoginRequest.java
+++ b/src/main/java/backend/yamukja/auth/dto/LoginRequest.java
@@ -1,6 +1,8 @@
 package backend.yamukja.auth.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 /**
@@ -8,6 +10,8 @@ import lombok.ToString;
  */
 @Getter
 @ToString
+@AllArgsConstructor
+@NoArgsConstructor
 public class LoginRequest {
     private String username;
     private String password;

--- a/src/main/java/backend/yamukja/auth/filter/JwtFilter.java
+++ b/src/main/java/backend/yamukja/auth/filter/JwtFilter.java
@@ -46,7 +46,6 @@ public class JwtFilter extends OncePerRequestFilter {
         String token = resolveToken(request);
 
         if (token != null) {
-            log.info("token: {}", token);
             // JWT -> Access Token 객체
             AccessToken accessToken = tokenService.convertAccessToken(token);
 

--- a/src/main/java/backend/yamukja/auth/model/ActiveUser.java
+++ b/src/main/java/backend/yamukja/auth/model/ActiveUser.java
@@ -13,7 +13,6 @@ import java.time.LocalDateTime;
 @Getter
 @RedisHash(value = "activeUser", timeToLive = 14400) // 4시간 저장
 @ToString
-@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ActiveUser {
     @Id

--- a/src/main/java/backend/yamukja/auth/model/UserCustom.java
+++ b/src/main/java/backend/yamukja/auth/model/UserCustom.java
@@ -49,6 +49,6 @@ public class UserCustom implements UserDetails {
 
     @Override
     public String getUsername() {
-        return null;
+        return username;
     }
 }

--- a/src/main/java/backend/yamukja/user/dto/UserResponse.java
+++ b/src/main/java/backend/yamukja/user/dto/UserResponse.java
@@ -1,10 +1,12 @@
 package backend.yamukja.user.dto;
 
 import backend.yamukja.user.entity.User;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.locationtech.jts.geom.Point;
 
 @Getter
+@EqualsAndHashCode
 public class UserResponse {
     private Long id;
     private String username;

--- a/src/main/java/backend/yamukja/user/services/UserService.java
+++ b/src/main/java/backend/yamukja/user/services/UserService.java
@@ -49,6 +49,7 @@ public class UserService {
     public UserResponse getDetail(Long id) {
         User user = userRepository.findById(id).orElseThrow(() -> new NoSuchElementException(ErrorMessage.USER_NOT_FOUND));
         return new UserResponse(user);
+    }
 
     @Transactional
     public void update(UpdateRequestDto request){

--- a/src/test/java/backend/yamukja/auth/controller/AuthControllerTest.java
+++ b/src/test/java/backend/yamukja/auth/controller/AuthControllerTest.java
@@ -1,0 +1,164 @@
+package backend.yamukja.auth.controller;
+
+import backend.yamukja.auth.constant.Constant;
+import backend.yamukja.auth.dto.AuthTokens;
+import backend.yamukja.auth.dto.LoginRequest;
+import backend.yamukja.auth.service.AuthService;
+import backend.yamukja.auth.service.TokenService;
+import backend.yamukja.common.config.SecurityConfig;
+import backend.yamukja.common.exception.RefreshTokenException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import java.util.NoSuchElementException;
+import java.util.stream.Stream;
+
+import static backend.yamukja.auth.constant.Constant.REFRESH_TOKEN_NOT_FOUND;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = AuthController.class)
+@Import(SecurityConfig.class)
+@ComponentScan(basePackages = {"backend.yamukja.auth.filter"})
+public class AuthControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AuthService authService;
+
+    @MockBean
+    private TokenService tokenService;
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("로그인 테스트: 성공 시나리오")
+    public void login_WhenValid_ShouldReturnAuthTokens() throws Exception {
+        // Given
+        LoginRequest loginRequest = new LoginRequest("username", "password");
+        AuthTokens authTokens = new AuthTokens("refreshToken", "accessToken", "username");
+
+        when(authService.login(any(LoginRequest.class))).thenReturn(authTokens);
+
+        // When, Then
+        mockMvc.perform(post("/api/login")
+                        .contentType("application/json")
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.accessToken").value("accessToken"))
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("REFRESH_TOKEN=refreshToken;")));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidLoginRequest")
+    @DisplayName("로그인 실패")
+    public void login_WhenInvalidRequestData_ShouldThrowException(RuntimeException exception, ResultMatcher status, String message) throws Exception {
+        // Given
+        LoginRequest loginRequest = new LoginRequest("username", "password");
+        when(authService.login(any(LoginRequest.class))).thenThrow(exception);
+
+        // When, Then
+        mockMvc.perform(post("/api/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(loginRequest)))
+                .andExpect(status)
+                .andExpect(jsonPath("$.message").value(message));
+    }
+
+    private static Stream<Arguments> provideInvalidLoginRequest() {
+        return Stream.of(
+                Arguments.of(
+                        new UsernameNotFoundException(Constant.WRONG_USERNAME),
+                        status().isNotFound(),
+                        Constant.WRONG_USERNAME
+                ),
+                Arguments.of(
+                        new BadCredentialsException(Constant.WRONG_PASSWORD),
+                        status().isUnauthorized(),
+                        Constant.WRONG_PASSWORD
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("Access Token 재발급: 성공 시나리오")
+    public void reissueToken_WhenValid_ShouldReturnNewAccessToken() throws Exception {
+        // Given
+        String refreshToken = "refreshToken";
+        String newAccessToken = "newAccessToken";
+
+        when(authService.reissueToken(refreshToken)).thenReturn(newAccessToken);
+
+        // When, Then
+        mockMvc.perform(post("/api/token/reissue")
+                        .cookie(new Cookie("REFRESH_TOKEN", refreshToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").value(newAccessToken));
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideInvalidReissueRequest")
+    @DisplayName("Access Token 재발급: 실패")
+    public void reissueToken_WhenInValid_ShouldThrowException(RuntimeException exception, ResultMatcher status, String message) throws Exception {
+        // Given
+        when(authService.reissueToken(any(String.class))).thenThrow(exception);
+
+        // When, Then
+        mockMvc.perform(post("/api/token/reissue")
+                        .cookie(new Cookie("REFRESH_TOKEN", "refreshToken")))
+                .andExpect(status)
+                .andExpect(jsonPath("$.message").value(message));
+    }
+
+    private static Stream<Arguments> provideInvalidReissueRequest() {
+        return Stream.of(
+                Arguments.of(
+                        new NoSuchElementException(REFRESH_TOKEN_NOT_FOUND),
+                        status().isNotFound(),
+                        Constant.REFRESH_TOKEN_NOT_FOUND
+                ),
+                Arguments.of(
+                        new RefreshTokenException(Constant.REFRESH_TOKEN_EXPIRED),
+                        status().isUnauthorized(),
+                        Constant.REFRESH_TOKEN_EXPIRED
+                )
+        );
+    }
+
+    @Test
+    @DisplayName("로그아웃")
+    public void logOut() throws Exception {
+        // Given
+        String refreshToken = "refreshToken";
+
+        // When, Then
+        mockMvc.perform(post("/api/logout")
+                        .cookie(new Cookie("REFRESH_TOKEN", refreshToken)))
+                .andExpect(status().isNoContent())
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("REFRESH_TOKEN=;")))
+                .andExpect(header().string(HttpHeaders.SET_COOKIE, containsString("Max-Age=0;")));
+
+        verify(authService).logOut(refreshToken);
+    }
+}

--- a/src/test/java/backend/yamukja/auth/filter/JwtExceptionFilterTest.java
+++ b/src/test/java/backend/yamukja/auth/filter/JwtExceptionFilterTest.java
@@ -1,0 +1,114 @@
+package backend.yamukja.auth.filter;
+
+import backend.yamukja.common.dto.ErrorResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static backend.yamukja.auth.constant.Constant.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JwtExceptionFilterTest {
+
+    @InjectMocks
+    private JwtExceptionFilter jwtExceptionFilter;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private PrintWriter printWriter;
+
+    @Test
+    @DisplayName("ExpiredJwtException 발생 시, 적절한 예외처리 객체 반환")
+    void doFilterInternal_WithExpiredJwtException() throws IOException, ServletException {
+        // Given
+        doThrow(new ExpiredJwtException(null, null, "Token expired"))
+                .when(filterChain).doFilter(request, response);
+        when(response.getWriter()).thenReturn(printWriter);
+
+        // When
+        jwtExceptionFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(response).setStatus(HttpStatus.UNAUTHORIZED.value());
+        verify(response).setContentType("application/json; charset=UTF-8");
+        ErrorResponseDto expectedErrorResponse = new ErrorResponseDto(ACCESS_TOKEN_EXPIRED, HttpStatus.UNAUTHORIZED);
+        verify(printWriter).write(new ObjectMapper().writeValueAsString(expectedErrorResponse));
+    }
+
+    @Test
+    @DisplayName("JwtException 발생 시, 적절한 예외처리 객체 반환")
+    void doFilterInternal_WithJwtException() throws IOException, ServletException {
+        // Given
+        doThrow(new JwtException("Invalid token"))
+                .when(filterChain).doFilter(request, response);
+        when(response.getWriter()).thenReturn(printWriter);
+
+        // When
+        jwtExceptionFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(response).setStatus(HttpStatus.UNAUTHORIZED.value());
+        verify(response).setContentType("application/json; charset=UTF-8");
+        ErrorResponseDto expectedErrorResponse = new ErrorResponseDto(INVALID_ACCESS_TOKEN, HttpStatus.UNAUTHORIZED);
+        verify(printWriter).write(new ObjectMapper().writeValueAsString(expectedErrorResponse));
+    }
+
+    @Test
+    @DisplayName("위 두 예외를 제외한 다른 예외 발생 시, 적절한 예외처리 객체 반환")
+    void doFilterInternal_WithUnexpectedException() throws IOException, ServletException {
+        // Given
+        doThrow(new RuntimeException("Unexpected error"))
+                .when(filterChain).doFilter(request, response);
+        when(response.getWriter()).thenReturn(printWriter);
+
+        // When
+        jwtExceptionFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(response).setStatus(HttpStatus.UNAUTHORIZED.value());
+        verify(response).setContentType("application/json; charset=UTF-8");
+        ErrorResponseDto expectedErrorResponse = new ErrorResponseDto(UNEXPECTED_ERROR_OCCUR, HttpStatus.UNAUTHORIZED);
+        verify(printWriter).write(new ObjectMapper().writeValueAsString(expectedErrorResponse));
+    }
+
+    @Test
+    @DisplayName("예외 발생하지 않으면 동작 X")
+    void doFilterInternal_WithoutException() throws IOException, ServletException {
+        // Given
+        doNothing().when(filterChain).doFilter(request, response);
+
+        // When
+        jwtExceptionFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(response, never()).setStatus(anyInt());
+        verify(response, never()).setContentType(anyString());
+        verify(response, never()).getWriter();
+    }
+}
+
+

--- a/src/test/java/backend/yamukja/auth/filter/JwtFilterTest.java
+++ b/src/test/java/backend/yamukja/auth/filter/JwtFilterTest.java
@@ -1,0 +1,96 @@
+package backend.yamukja.auth.filter;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import backend.yamukja.auth.service.TokenService;
+import backend.yamukja.auth.token.AccessToken;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import java.io.IOException;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class JwtFilterTest {
+
+    @Mock
+    private TokenService tokenService;
+
+    @InjectMocks
+    private JwtFilter jwtFilter;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Test
+    @DisplayName("유효한 액세스 토큰 도착 시, 인증 정보 설정")
+    public void doFilterInternal_WithValidToken_ShouldSetAuthentication() throws ServletException, IOException {
+        // Given
+        String validToken = "ValidToken";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader(JwtFilter.AUTHORIZATION_HEADER, JwtFilter.BEARER_PREFIX + validToken);
+
+        Claims claims = mock(Claims.class);
+        when(claims.get("aud")).thenReturn("1");
+        when(claims.getSubject()).thenReturn("username");
+
+        AccessToken accessToken = mock(AccessToken.class);
+        when(accessToken.getData()).thenReturn(claims);
+
+        when(tokenService.convertAccessToken(anyString())).thenReturn(accessToken);
+
+        // When
+        jwtFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(tokenService, times(1)).convertAccessToken(validToken);
+        verify(tokenService, times(1)).setAuthentication(1L, "username");
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("잘못된 토큰이 도착 시, 예외가 발생하고 인증 정보 설정 X")
+    public void doFilterInternal_WithInvalidToken_ShouldNotSetAuthentication() throws ServletException, IOException {
+        // Given
+        String invalidToken = "InvalidToken";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        request.addHeader(JwtFilter.AUTHORIZATION_HEADER, JwtFilter.BEARER_PREFIX + invalidToken);
+
+        when(tokenService.convertAccessToken(anyString())).thenThrow(JwtException.class);
+
+        // When
+        assertThrows(JwtException.class, () -> jwtFilter.doFilterInternal(request, response, filterChain));
+
+        // Then
+        verify(tokenService, times(1)).convertAccessToken(invalidToken);
+        verify(tokenService, never()).setAuthentication(anyLong(), anyString());
+    }
+
+    @Test
+    @DisplayName("토큰이 없는 요청 도착 시, 인증 정보 설정 X")
+    public void doFilterInternal_NoToken_ShouldNotSetAuthentication() throws ServletException, IOException {
+        // Given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // When
+        jwtFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(tokenService, never()).convertAccessToken(anyString());
+        verify(tokenService, never()).setAuthentication(anyLong(), anyString());
+        verify(filterChain, times(1)).doFilter(request, response);
+    }
+}

--- a/src/test/java/backend/yamukja/auth/service/AuthServiceImplTest.java
+++ b/src/test/java/backend/yamukja/auth/service/AuthServiceImplTest.java
@@ -1,0 +1,124 @@
+package backend.yamukja.auth.service;
+
+import backend.yamukja.auth.constant.Constant;
+import backend.yamukja.auth.dto.AuthTokens;
+import backend.yamukja.auth.dto.LoginRequest;
+import backend.yamukja.auth.token.AccessToken;
+import backend.yamukja.auth.token.RefreshToken;
+import backend.yamukja.common.exception.RefreshTokenException;
+import backend.yamukja.user.entity.User;
+import backend.yamukja.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class AuthServiceImplTest {
+
+    @InjectMocks
+    private AuthServiceImpl authService;
+
+    @Mock
+    private TokenService tokenService;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Mock
+    private UserRepository userRepository;
+
+    private Key key;
+
+    @BeforeEach
+    void setUp() {
+        String secret = "testsecrettestsecrettestsecrettestsecrettestsecret";
+        key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+    }
+
+    @Test
+    @DisplayName("로그인: 성공 시나리오")
+    public void login_WhenUserFound_ShouldReturnAuthTokens() {
+        // Given
+        LoginRequest loginRequest = new LoginRequest("username", "password");
+        User user = User.builder().id(1L).userId("username").build();
+        when(userRepository.findByUserId("username")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("password", user.getPassword())).thenReturn(true);
+
+        AccessToken accessToken = new AccessToken(user.getId(), user.getUserId(), key);
+        RefreshToken refreshToken = new RefreshToken();
+        when(tokenService.generateAccessToken(user.getId(), user.getUserId())).thenReturn(accessToken);
+        when(tokenService.generateRefreshToken(user.getId(), user.getUserId())).thenReturn(refreshToken);
+
+        // When
+        AuthTokens authTokens = authService.login(loginRequest);
+
+        // Then
+        assertNotNull(authTokens);
+        assertEquals(accessToken.getToken(), authTokens.getLoginResponse().getAccessToken());
+        assertEquals(refreshToken.getToken(), authTokens.getRefreshToken());
+    }
+
+    @Test
+    @DisplayName("로그인 실패: 아이디 틀림")
+    public void login_WhenInvalidPassword_ShouldThrowException() throws Exception {
+        // Given
+        LoginRequest loginRequest = new LoginRequest("username", "password");
+        User user = User.builder().id(1L).userId("username").build();
+        when(userRepository.findByUserId("username")).thenReturn(Optional.of(user));
+        when(passwordEncoder.matches("password", user.getPassword())).thenReturn(false);
+
+        // When, Then
+        BadCredentialsException e = assertThrows(BadCredentialsException.class, () -> authService.login(loginRequest));
+        assertEquals(Constant.WRONG_PASSWORD, e.getMessage());
+    }
+
+    @Test
+    @DisplayName("로그인 실패: 아이디 틀림")
+    public void login_WhenUsernameNotFound_ShouldThrowNoSuchElementException() throws Exception {
+        // Given
+        LoginRequest loginRequest = new LoginRequest("username", "password");
+        when(userRepository.findByUserId("username")).thenReturn(Optional.empty());
+
+        // When, Then
+        NoSuchElementException e = assertThrows(NoSuchElementException.class, () -> authService.login(loginRequest));
+        assertEquals(Constant.WRONG_USERNAME, e.getMessage());
+    }
+
+    @Test
+    @DisplayName("로그아웃: 성공 시나리오")
+    public void logOut_WhenValidToken_ShouldCallDeleteRefreshToken() {
+        // Given
+        String refreshToken = "validRefreshToken";
+
+        // When
+        authService.logOut(refreshToken);
+
+        // Then
+        verify(tokenService, times(1)).deleteRefreshToken(refreshToken);
+    }
+
+    @Test
+    @DisplayName("로그아웃: refresh token이 없으면 RefreshTokenException")
+    public void logOut_WhenNoToken_ShouldThrowException() {
+        // Given
+        String refreshToken = "";
+
+        // When, Then
+        assertThrows(RefreshTokenException.class, () -> authService.logOut(refreshToken));
+    }
+}

--- a/src/test/java/backend/yamukja/auth/service/TokenServiceImplTest.java
+++ b/src/test/java/backend/yamukja/auth/service/TokenServiceImplTest.java
@@ -1,0 +1,171 @@
+package backend.yamukja.auth.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import backend.yamukja.auth.constant.Constant;
+import backend.yamukja.auth.model.ActiveUser;
+import backend.yamukja.auth.model.UserCustom;
+import backend.yamukja.auth.repository.ActiveUserRepository;
+import backend.yamukja.auth.token.AccessToken;
+import backend.yamukja.auth.token.RefreshToken;
+import backend.yamukja.common.exception.RefreshTokenException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.LocalDateTime;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TokenServiceImplTest {
+    @Mock
+    private ActiveUserRepository activeUserRepository;
+
+    @InjectMocks
+    private TokenServiceImpl tokenService;
+
+    private Key key;
+
+    @BeforeEach
+    void setUp() {
+        String secret = "testsecrettestsecrettestsecrettestsecrettestsecret";
+
+        // secret 필드 mocking
+        ReflectionTestUtils.setField(tokenService, "secret", secret);
+
+        // PostConstruct 호출
+        tokenService.init();
+
+        this.key = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256");
+    }
+
+    @Test
+    @DisplayName("JWT Token -> Access Token 객체")
+    void convertAccessToken() {
+        // given
+        String username = "testUser";
+        AccessToken testToken = new AccessToken(1L, username, key);
+
+        // when
+        AccessToken token = tokenService.convertAccessToken(testToken.getToken());
+
+        // then
+        assertNotNull(token);
+        assertEquals(testToken.getToken(), token.getToken());
+        assertEquals(username, token.getData().getSubject());
+    }
+
+    @Test
+    @DisplayName("Authentication 세팅")
+    void setAuthentication() {
+        // given
+        Long userId = 1L;
+        String username = "testUser";
+
+        // when
+        tokenService.setAuthentication(userId, username);
+
+        // then
+        UsernamePasswordAuthenticationToken auth = (UsernamePasswordAuthenticationToken) SecurityContextHolder.getContext().getAuthentication();
+        UserCustom userCustom = (UserCustom) auth.getPrincipal();
+
+        assertNotNull(auth);
+        assertEquals(userId, userCustom.getId());
+        assertEquals(username, userCustom.getUsername());
+        assertTrue(auth.getAuthorities().contains(new SimpleGrantedAuthority("USER")));
+    }
+
+    @Test
+    @DisplayName("Refresh Token 생성 및 저장")
+    void generateRefreshToken() {
+        Long userId = 1L;
+        String username = "testUser";
+        RefreshToken refreshToken = new RefreshToken();
+
+        when(activeUserRepository.save(any(ActiveUser.class))).thenReturn(new ActiveUser(userId, username, refreshToken));
+
+        RefreshToken result = tokenService.generateRefreshToken(userId, username);
+
+        assertNotNull(result);
+        verify(activeUserRepository).save(any(ActiveUser.class));
+    }
+
+    @Test
+    @DisplayName("Access Token 재발급: 성공 시나리오")
+    void refreshAccessToken_WhenTokenIsValid_ShouldReturnNewAccessToken() {
+        // Given
+        String refreshTokenString = "validRefreshToken";
+        Long userId = 1L;
+        String username = "testUser";
+        RefreshToken refreshToken = new RefreshToken();
+
+        ActiveUser activeUser = new ActiveUser(userId, username, refreshToken);
+
+        when(activeUserRepository.findById(refreshTokenString)).thenReturn(Optional.of(activeUser));
+
+        // When
+        AccessToken accessToken = tokenService.refreshAccessToken(refreshTokenString);
+
+        assertNotNull(accessToken);
+        assertEquals(username, accessToken.getData().getSubject());
+        assertTrue(accessToken.getExpiredAt().isAfter(LocalDateTime.now()));
+    }
+
+    @Test
+    @DisplayName("Redis에 해당 Refresh Token이 존재하지 않으면 NoSuchElementException")
+    void refreshAccessToken_WhenRefreshTokenIsNotInRedis_ShouldThrowException() {
+        // Given
+        when(activeUserRepository.findById(anyString())).thenReturn(Optional.empty());
+
+        // When, then
+        NoSuchElementException e = assertThrows(NoSuchElementException.class, () ->
+                tokenService.refreshAccessToken("expired refresh token")
+        );
+
+        assertEquals(Constant.REFRESH_TOKEN_NOT_FOUND, e.getMessage());
+    }
+
+    @Test
+    @DisplayName("Refresh Token 만료 시 RefreshTokenException")
+    void refreshAccessToken_WhenTokenIsExpired_ShouldThrowRefreshTokenException() {
+        String refreshTokenString = "expiredRefreshToken";
+        LocalDateTime expiredDate = LocalDateTime.now().minusDays(1); // 이미 만료된 토큰
+
+        ActiveUser activeUser = mock(ActiveUser.class);
+        when(activeUser.getExpiredAt()).thenReturn(expiredDate);
+
+        when(activeUserRepository.findById(refreshTokenString)).thenReturn(Optional.of(activeUser));
+
+        RefreshTokenException e = assertThrows(RefreshTokenException.class, () ->
+                tokenService.refreshAccessToken(refreshTokenString)
+        );
+
+        assertEquals(Constant.REFRESH_TOKEN_EXPIRED, e.getMessage());
+    }
+
+    @Test
+    @DisplayName("리프레쉬 토큰 삭제")
+    void testDeleteRefreshToken() {
+        String refreshTokenString = "tokenToDelete";
+
+        tokenService.deleteRefreshToken(refreshTokenString);
+
+        verify(activeUserRepository).deleteById(refreshTokenString);
+    }
+}

--- a/src/test/java/backend/yamukja/common/CustomSecurityContextFactory.java
+++ b/src/test/java/backend/yamukja/common/CustomSecurityContextFactory.java
@@ -1,0 +1,28 @@
+package backend.yamukja.common;
+
+import backend.yamukja.auth.model.UserCustom;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.Collections;
+
+public class CustomSecurityContextFactory implements WithSecurityContextFactory<WithUserCustom> {
+    @Override
+    public SecurityContext createSecurityContext(WithUserCustom mockUserCustom) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        UserCustom userCustom = new UserCustom(Long.valueOf(mockUserCustom.id()), mockUserCustom.username());
+
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(
+                userCustom,
+                null,
+                Collections.singleton(new SimpleGrantedAuthority("USER"))
+        );
+
+        context.setAuthentication(token);
+        return context;
+    }
+}

--- a/src/test/java/backend/yamukja/common/WithUserCustom.java
+++ b/src/test/java/backend/yamukja/common/WithUserCustom.java
@@ -1,0 +1,17 @@
+package backend.yamukja.common;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@WithSecurityContext(factory = CustomSecurityContextFactory.class)
+public @interface WithUserCustom {
+    String id() default "1";
+    String username() default "username";
+    String role() default "USER";
+}

--- a/src/test/java/backend/yamukja/user/controllers/UserControllerTest.java
+++ b/src/test/java/backend/yamukja/user/controllers/UserControllerTest.java
@@ -1,0 +1,49 @@
+package backend.yamukja.user.controllers;
+
+import backend.yamukja.auth.service.TokenService;
+import backend.yamukja.common.WithUserCustom;
+import backend.yamukja.user.dto.UserResponse;
+import backend.yamukja.user.entity.User;
+import backend.yamukja.user.services.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+
+@WebMvcTest(controllers = UserController.class)
+class UserControllerTest {
+    @MockBean
+    private UserService userService;
+
+    @MockBean
+    private TokenService tokenService;
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    @WithUserCustom
+    @DisplayName("유저 상세정보 반환")
+    void getDetail() throws Exception {
+        Long userId = 1L;
+        User user = User.builder().id(1L).userId("testUser").geography(null).isLunchRecommend(false).build();
+        UserResponse userResponse = new UserResponse(user);
+
+        when(userService.getDetail(userId)).thenReturn(userResponse);
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/user")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(MockMvcResultMatchers.jsonPath("$.id").value(userId))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.username").value("testUser"))
+                .andDo(print());
+    }
+}

--- a/src/test/java/backend/yamukja/user/services/UserServiceTest.java
+++ b/src/test/java/backend/yamukja/user/services/UserServiceTest.java
@@ -1,0 +1,51 @@
+package backend.yamukja.user.services;
+
+import backend.yamukja.user.constants.ErrorMessage;
+import backend.yamukja.user.dto.UserResponse;
+import backend.yamukja.user.entity.User;
+import backend.yamukja.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("사용자 상세 정보: 성공 시나리오")
+    void getDetail_WhenUserAuthenticated_ShouldReturnUserDetailResponse() {
+        Long userId = 1L;
+        User user = User.builder().id(userId).userId("testUser").geography(null).isLunchRecommend(false).build();
+        UserResponse expectedResponse = new UserResponse(user);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        UserResponse actualResponse = userService.getDetail(userId);
+        assertEquals(expectedResponse, actualResponse);
+    }
+
+    @Test
+    @DisplayName("사용자 상세 정보: DB에 해당 유저가 없는 경우")
+    void getDetail_WhenUserNotFound_ShouldThrowNoSuchElementException() {
+        Long userId = 1L;
+
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        NoSuchElementException e = assertThrows(NoSuchElementException.class, () -> userService.getDetail(userId));
+        assertEquals(ErrorMessage.USER_NOT_FOUND, e.getMessage());
+    }
+}


### PR DESCRIPTION
## 작업 내용
> 1. 테스트를 위한 Security Context, 사용자 인증정보 모킹 어노테이션 구현
> 1.1 테스트코드에 인증된 사용자 정보(`@AuthenticationPrincipal`)이 필요하다면, `@WithUserCustom` 어노테이션을 사용해주세요.
> 1.2 default 값은 id == 1, username == "username"입니다.
> 1.3 데이터를 수정하고 싶다면 `@WithUserCustom(username = "testuser")` 와 같은 방식으로 사용하면 됩니다. 
> 1.4 상세 구현을 보고싶다면, /**test**/java/backend/yamukja/**common**을 확인해주세요

> 2. 인증 테스트 코드 
> 3. 사용자 상세 정보 테스트 코드 

### #️⃣이슈 번호
> #22 